### PR TITLE
Fix an index out of bounds issue

### DIFF
--- a/src/org/openstreetmap/josm/plugins/auto_tools/actions/SplittingTool.java
+++ b/src/org/openstreetmap/josm/plugins/auto_tools/actions/SplittingTool.java
@@ -349,7 +349,8 @@ public class SplittingTool extends MapMode {
         Way selectedWay = null;
 
         // Finally, applicableWays contains only one perfect way
-        if (selectionToSplit != null && selectionToSplit.size() == 1 && applicableWays.contains(new ArrayList<>(Utils.filteredCollection(selectionToSplit, Way.class)).get(0))) {
+        ArrayList<Way> list = new ArrayList<>(Utils.filteredCollection(selectionToSplit, Way.class));
+        if (selectionToSplit != null && selectionToSplit.size() == 1 && list.size() > 1 && applicableWays.contains(list.get(0))) {
             selectedWay = new ArrayList<>(Utils.filteredCollection(selectionToSplit, Way.class)).get(0);
         } else {
             selectedWay = applicableWays.get(0);


### PR DESCRIPTION
This fixes an error found after switching to `Utils.filteredCollection` from `OsmPrimitive.getFilteredList`.

Signed-off-by: Taylor Smock <taylor.smock@kaartgroup.com>

```
URL:https://josm.openstreetmap.de/svn/trunk
Repository:UUID: 0c6e7542-c601-0410-84e7-c038aed88b3b
Last:Changed Date: 2019-04-10 14:31:02 +0200 (Wed, 10 Apr 2019)
Build-Date:2019-04-11 01:30:53
Revision:14983
Relative:URL: ^/trunk

Identification: JOSM/1.5 (14983 en) Mac OS X 10.14.1
OS Build number: Mac OS X 10.14.1 (18B75)
Memory Usage: 1058 MB / 1820 MB (142 MB allocated, but free)
Java version: 1.8.0_201-b09, Oracle Corporation, Java HotSpot(TM) 64-Bit Server VM
Screen: Display 188947522 1920x1080, Display 69981408 2048x1152
Maximum Screen Size: 2048x1152
VM arguments: [-Djava.security.policy=file:<java.home>/lib/security/javaws.policy, -DtrustProxy=true, -Djnlpx.home=<java.home>/bin, -Djava.security.manager, -Djnlpx.origFilenameArg=${HOME}/Library/Application Support/Oracle/Java/Deployment/cache/6.0/31/583aa85f-7f8234e1, -Djnlpx.remove=false, -Dsun.awt.warmup=true, -Djava.util.Arrays.useLegacyMergeSort=true, -Djnlpx.heapsize=NULL,2048m, -Dmacosx.jnlpx.dock.name=JOSM (development version), -Dmacosx.jnlpx.dock.icon=${HOME}/Library/Application Support/Oracle/Java/Deployment/cache/6.0/25/4c122699-477b07e1.icns, -Djnlp.application.href=https://josm.openstreetmap.de/download/josm-latest.jnlp , -Djnlpx.jvm="<java.home>/bin/java"]
Dataset consistency test: No problems found

Plugins:
+ Mapillary (1.5.18)
+ apache-commons (34506)
+ apache-http (34632)
+ auto_tools (73)
+ buildings_tools (34968)
+ ejml (34389)
+ geotools (34513)
+ imagery_offset_db (34867)
+ jaxb (34678)
+ jna (34867)
+ jts (34524)
+ markseen (13)
+ opendata (34911)
+ utilsplugin2 (34932)

Map paint styles:
+ https://raw.githubusercontent.com/KaartGroup/Kaart-Styles/master/Kaart-Styles.mapcss
+ https://josm.openstreetmap.de/josmfile?page=Styles/Lane_and_Road_Attributes&zip=1
+ https://raw.githubusercontent.com/KaartGroup/Kaart-Styles/master/Overlapping%20Ways.mapcss
- https://josm.openstreetmap.de/josmfile?page=Styles/Coloured_Streets&zip=1

Validator rules:
+ https://raw.githubusercontent.com/KaartGroup/KaartValidator/master/kaart.validator.mapcss

Last errors/warnings:
- W: java.io.IOException: Attribution is not loaded yet
- W: java.io.IOException: Attribution is not loaded yet
- W: java.io.IOException: Attribution is not loaded yet
- W: java.io.IOException: Attribution is not loaded yet
- W: java.io.IOException: Attribution is not loaded yet
- W: java.io.IOException: Attribution is not loaded yet
- W: java.io.IOException: Attribution is not loaded yet
- W: java.io.IOException: Attribution is not loaded yet
- E: Handled by bug report queue: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
- W: Warning - <html>JOSM could not find information about the following plugins:<ul><li>auto_tools</li><li>imagery_offset_db</li><li>apache-commons</li><li>geotools</li><li>opendata</li><li>jts</li><li>Mapillary</li><li>ejml</li><li>jaxb</li><li>utilsplugin2</li><li>markseen</li><li>buildings_tools</li><li>jna</li><li>apache-http</li></ul>The plugins are not going to be loaded.</html>


=== REPORTED CRASH DATA ===
BugReportExceptionHandler#handleException:
No data collected.

Warning issued by: BugReportExceptionHandler#handleException

=== STACK TRACE ===
Thread: AWT-EventQueue-2 (39) of javawsApplicationThreadGroup
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:657)
	at java.util.ArrayList.get(ArrayList.java:433)
	at org.openstreetmap.josm.plugins.auto_tools.actions.SplittingTool.SplitRoad(SplittingTool.java:352)
	at org.openstreetmap.josm.plugins.auto_tools.actions.SplittingTool.mouseReleased(SplittingTool.java:133)
	at java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:290)
	at java.awt.Component.processMouseEvent(Component.java:6539)
	at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
	at java.awt.Component.processEvent(Component.java:6304)
	at java.awt.Container.processEvent(Container.java:2239)
	at java.awt.Component.dispatchEventImpl(Component.java:4889)
	at java.awt.Container.dispatchEventImpl(Container.java:2297)
	at java.awt.Component.dispatchEvent(Component.java:4711)
	at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4904)
	at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4535)
	at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4476)
	at java.awt.Container.dispatchEventImpl(Container.java:2283)
	at java.awt.Window.dispatchEventImpl(Window.java:2746)
	at java.awt.Component.dispatchEvent(Component.java:4711)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:760)
	at java.awt.EventQueue.access$500(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.awt.EventQueue$3.run(EventQueue.java:703)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:84)
	at java.awt.EventQueue$4.run(EventQueue.java:733)
	at java.awt.EventQueue$4.run(EventQueue.java:731)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:730)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```